### PR TITLE
Changed namespace generation to use EeConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,15 @@ Key names are automatically parsed from KumuluzEE to etcd format (e.g. `environm
 `environments/dev/name`).
 
 Configuration properties are in etcd stored in a dedicated namespace, which is automatically generated from 
-configuration keys `kumuluzee.env`, `kumuluzee.service-name` and `kumuluzee.version`. Example: `kumuluzee.env: dev`,
-`kumuluzee.service-name: customer-service`, `kumuluzee.version: 1.2.3` is
-mapped to namespace `environments/dev/services/customer-service/1.2.3/config`. If `kumuluzee.env` or `kumuluzee.version`
-keys are not specified, defaults are used (`dev` and `1.0.0`). If `kumuluzee.service-name` is not specified, namespace
-`environments/<environment>/services/config` is used. Automatic namespace generation can be overwritten with key 
-`kumuluzee.config.namespace`. Example: `kumuluzee.config.namespace: environments/dev/services/config`. 
+configuration keys `kumuluzee.env.name`, `kumuluzee.name` and `kumuluzee.version`. Example: `kumuluzee.env.name: dev`,
+`kumuluzee.name: customer-service`, `kumuluzee.version: 1.2.3` is
+mapped to namespace `environments/dev/services/customer-service/1.2.3/config`. If `kumuluzee.env.name` or
+`kumuluzee.version` keys are not specified, defaults are used (`dev` and `1.0.0`). If `kumuluzee.service-name` is not
+specified, namespace `environments/<environment>/services/config` is used. Automatic namespace generation can be
+overwritten with key `kumuluzee.config.namespace`. Example:
+`kumuluzee.config.namespace: environments/dev/services/config`.
 
-Namespace is used as a first part of the key used for etcd key/value store. Example: with set `kumuluzee.env: dev`, 
+Namespace is used as a first part of the key used for etcd key/value store. Example: with set `kumuluzee.env.name: dev`, 
 field `port` from example bellow is in etcd stored in key `/environments/dev/services/test-service/config/port`.
 
 **Configuration properties inside Consul**

--- a/common/src/main/java/com/kumuluz/ee/config/utils/InitializationUtils.java
+++ b/common/src/main/java/com/kumuluz/ee/config/utils/InitializationUtils.java
@@ -21,6 +21,7 @@
 
 package com.kumuluz.ee.config.utils;
 
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 
 import java.util.Optional;
@@ -32,7 +33,7 @@ import java.util.Optional;
  */
 public class InitializationUtils {
 
-    public static String getNamespace(ConfigurationUtil configurationUtil, String implementation) {
+    public static String getNamespace(EeConfig eeConfig, ConfigurationUtil configurationUtil, String implementation) {
         String universalNamespace = configurationUtil.get("kumuluzee.config.namespace")
                 .orElse(null);
         if (universalNamespace != null && !universalNamespace.isEmpty()) {
@@ -44,10 +45,21 @@ public class InitializationUtils {
             return implementationNamespace;
         }
 
-        String env = configurationUtil.get("kumuluzee.env").orElse("dev");
-        String serviceName = configurationUtil.get("kumuluzee.service-name").orElse(null);
+        String env = eeConfig.getEnv().getName();
+        if(env == null || env.isEmpty()) {
+            env = configurationUtil.get("kumuluzee.env").orElse("dev");
+        }
+
+        String serviceName = eeConfig.getName();
+        if(serviceName == null || serviceName.isEmpty()) {
+            serviceName = configurationUtil.get("kumuluzee.service-name").orElse(null);
+        }
+
         if(serviceName != null && !serviceName.isEmpty()) {
-            String serviceVersion = configurationUtil.get("kumuluzee.version").orElse("1.0.0");
+            String serviceVersion = eeConfig.getVersion();
+            if(serviceVersion == null || serviceVersion.isEmpty()) {
+                serviceVersion = configurationUtil.get("kumuluzee.version").orElse("1.0.0");
+            }
             return "environments/" + env + "/services/" + serviceName + "/" + serviceVersion + "/config";
         } else {
             return "environments/" + env + "/services/config";

--- a/consul/src/main/java/com/kumuluz/ee/config/consul/ConsulConfigExtension.java
+++ b/consul/src/main/java/com/kumuluz/ee/config/consul/ConsulConfigExtension.java
@@ -44,7 +44,7 @@ public class ConsulConfigExtension implements ConfigExtension {
     @Override
     public void init(KumuluzServerWrapper kumuluzServerWrapper, EeConfig eeConfig) {
         log.info("Initialising Consul configuration source.");
-        configurationSource = new ConsulConfigurationSource();
+        configurationSource = new ConsulConfigurationSource(eeConfig);
     }
 
     @Override

--- a/consul/src/main/java/com/kumuluz/ee/config/consul/ConsulConfigurationSource.java
+++ b/consul/src/main/java/com/kumuluz/ee/config/consul/ConsulConfigurationSource.java
@@ -20,6 +20,7 @@
 */
 package com.kumuluz.ee.config.consul;
 
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.config.utils.InitializationUtils;
 import com.kumuluz.ee.config.utils.ParseUtils;
 import com.kumuluz.ee.configuration.ConfigurationSource;
@@ -66,13 +67,19 @@ public class ConsulConfigurationSource implements ConfigurationSource {
     private int startRetryDelay;
     private int maxRetryDelay;
 
+    private EeConfig eeConfig;
+
+    public ConsulConfigurationSource(EeConfig eeConfig) {
+        this.eeConfig = eeConfig;
+    }
+
 
     @Override
     public void init(ConfigurationDispatcher configurationDispatcher) {
 
         ConfigurationUtil configurationUtil = ConfigurationUtil.getInstance();
 
-        this.namespace = InitializationUtils.getNamespace(configurationUtil, "consul");
+        this.namespace = InitializationUtils.getNamespace(this.eeConfig, configurationUtil, "consul");
         log.info("Using namespace: " + this.namespace);
 
         // get retry delays

--- a/etcd/src/main/java/com/kumuluz/ee/config/etcd/Etcd2ConfigExtension.java
+++ b/etcd/src/main/java/com/kumuluz/ee/config/etcd/Etcd2ConfigExtension.java
@@ -44,7 +44,7 @@ public class Etcd2ConfigExtension implements ConfigExtension {
     @Override
     public void init(KumuluzServerWrapper kumuluzServerWrapper, EeConfig eeConfig) {
         log.info("Initialising etcd2 configuration source.");
-        configurationSource = new Etcd2ConfigurationSource();
+        configurationSource = new Etcd2ConfigurationSource(eeConfig);
     }
 
     @Override

--- a/etcd/src/main/java/com/kumuluz/ee/config/etcd/Etcd2ConfigurationSource.java
+++ b/etcd/src/main/java/com/kumuluz/ee/config/etcd/Etcd2ConfigurationSource.java
@@ -21,6 +21,7 @@
 
 package com.kumuluz.ee.config.etcd;
 
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.config.utils.InitializationUtils;
 import com.kumuluz.ee.config.utils.ParseUtils;
 import com.kumuluz.ee.configuration.ConfigurationSource;
@@ -64,6 +65,12 @@ public class Etcd2ConfigurationSource implements ConfigurationSource {
     private int startRetryDelay;
     private int maxRetryDelay;
 
+    private EeConfig eeConfig;
+
+    public Etcd2ConfigurationSource(EeConfig eeConfig) {
+        this.eeConfig = eeConfig;
+    }
+
     @Override
     public void init(ConfigurationDispatcher configurationDispatcher) {
 
@@ -71,7 +78,7 @@ public class Etcd2ConfigurationSource implements ConfigurationSource {
 
         ConfigurationUtil configurationUtil = ConfigurationUtil.getInstance();
         // get namespace
-        this.namespace = InitializationUtils.getNamespace(configurationUtil, "etcd");
+        this.namespace = InitializationUtils.getNamespace(eeConfig, configurationUtil, "etcd");
         log.info("Using namespace: " + this.namespace);
 
         // get user credentials

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kumuluzee.version>2.3.0-SNAPSHOT</kumuluzee.version>
+        <kumuluzee.version>2.4.0-SNAPSHOT</kumuluzee.version>
 
         <nexus.staging.plugin.version>1.6.8</nexus.staging.plugin.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>


### PR DESCRIPTION
Uses new keys for namespace genaration:
- `kumuluzee.name`
- `kumuluzee.version`
- `kumuluzee.env.name`

If new keys are not present, old keys are checked for backwards compatibility.