### PR TITLE
Config framework update

### DIFF
--- a/consul/src/main/java/com/kumuluz/ee/config/consul/ConsulConfigurationSource.java
+++ b/consul/src/main/java/com/kumuluz/ee/config/consul/ConsulConfigurationSource.java
@@ -361,6 +361,11 @@ public class ConsulConfigurationSource implements ConfigurationSource {
         set(key, value.toString());
     }
 
+    @Override
+    public Integer getOrdinal() {
+        return getInteger(CONFIG_ORDINAL).orElse(110);
+    }
+
     private String parseKeyNameFromConsul(String key) {
         return key.substring(this.namespace.length() + 1).replace("/", ".").replace(".[", "[");
     }

--- a/etcd/src/main/java/com/kumuluz/ee/config/etcd/Etcd2ConfigurationSource.java
+++ b/etcd/src/main/java/com/kumuluz/ee/config/etcd/Etcd2ConfigurationSource.java
@@ -402,6 +402,11 @@ public class Etcd2ConfigurationSource implements ConfigurationSource {
         set(key, value.toString());
     }
 
+    @Override
+    public Integer getOrdinal() {
+        return getInteger(CONFIG_ORDINAL).orElse(110);
+    }
+
     private String parseKeyNameForEtcd(String key) {
 
         key = key.replace("[", ".[");

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kumuluzee.version>2.4.0</kumuluzee.version>
+        <kumuluzee.version>2.5.0-SNAPSHOT</kumuluzee.version>
 
         <consul-client.version>0.16.3</consul-client.version>
         <etcd4j.version>2.13.0</etcd4j.version>


### PR DESCRIPTION
Adapted to changes in configuration framework.

- Updated KumuluzEE version to 2.5.0-SNAPSHOT
- Implemented `getOrdinal()` in configuration sources - default ordinal is 110